### PR TITLE
Fix spread node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babylon": "^6.16.1",
     "mocha": "^3.2.0"

--- a/src/index.js
+++ b/src/index.js
@@ -93,17 +93,17 @@ function h(t, componentOrTag, properties, children) {
 
     const dataSet = (
       properties.properties
-        .find((prop) => prop.key.name === 'dataset' && t.isObjectExpression(prop.value))
+        .find((prop) => prop.key && prop.key.name === 'dataset' && t.isObjectExpression(prop.value))
     );
 
     const attributes = (
       properties.properties
-        .find((prop) => prop.key.name === 'attributes' && t.isObjectExpression(prop.value))
+        .find((prop) => prop.key && prop.key.name === 'attributes' && t.isObjectExpression(prop.value))
     );
 
     const attrChildren = (
       properties.properties
-        .find((prop) => prop.key.name === 'children' && t.isArrayExpression(prop.value))
+        .find((prop) => prop.key && prop.key.name === 'children' && t.isArrayExpression(prop.value))
     );
 
     if (dataSet) {
@@ -119,7 +119,7 @@ function h(t, componentOrTag, properties, children) {
         });
 
       properties.properties = properties.properties
-        .filter((prop) => prop.key.name !== 'dataset');
+        .filter((prop) => !prop.key || prop.key.name !== 'dataset');
     }
 
     if (attributes) {
@@ -135,7 +135,7 @@ function h(t, componentOrTag, properties, children) {
         });
 
       properties.properties = properties.properties
-        .filter((prop) => prop.key.name !== 'attributes');
+        .filter((prop) => !prop.key || prop.key.name !== 'attributes');
     }
 
     if (attrChildren) {

--- a/test/fixtures/.babelrc
+++ b/test/fixtures/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "transform-object-rest-spread",
     ["../../src"]
   ]
 }

--- a/test/fixtures/actual.js
+++ b/test/fixtures/actual.js
@@ -30,6 +30,9 @@ h('div', {dataset: {foo: 'bar', bar: 'oops'}});
 
 h('div', {attributes: {title: 'foo'}});
 
+const obj = { a: 1 }
+h(Component, { ...obj, b: 2 });
+
 h(Component);
 
 h(Component, {title: 'Hello World!'}, [

--- a/test/fixtures/expected.js
+++ b/test/fixtures/expected.js
@@ -1,3 +1,5 @@
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 React.createElement('h1');
 
 React.createElement('h1', {
@@ -33,6 +35,9 @@ React.createElement('div', {
 React.createElement('div', {
   title: 'foo'
 });
+
+const obj = { a: 1 };
+React.createElement(Component, _extends({}, obj, { b: 2 }));
 
 React.createElement(Component);
 


### PR DESCRIPTION
Code `h(Menu, { ...data, path })` will contain Spread node and this node doesn’t have `key` property.

So I got issue:

```
Module build failed: TypeError: /home/ai/Dev/amplifr-front/components/page/menu.js: Cannot read property 'name' of undefined
    at /home/ai/Dev/amplifr-front/node_modules/babel-plugin-react-hyperscript/lib/index.js:115:22
    at Array.find (native)
    at h (/home/ai/Dev/amplifr-front/node_modules/babel-plugin-react-hyperscript/lib/index.js:114:41)
    at PluginPass.CallExpression (/home/ai/Dev/amplifr-front/node_modules/babel-plugin-react-hyperscript/lib/index.js:32:97)
    at newFn (/home/ai/Dev/amplifr-front/node_modules/babel-traverse/lib/visitors.js:276:21)
```

This PR will fix it.

@roman01la thanks for great plugin.